### PR TITLE
mss_rtc: mss_rtc.h: fix compilation of rtc driver

### DIFF
--- a/drivers/mss/mss_rtc/mss_rtc.h
+++ b/drivers/mss/mss_rtc/mss_rtc.h
@@ -188,6 +188,8 @@
 #ifndef MSS_RTC_H_
 #define MSS_RTC_H_
 
+#include "mpfs_hal/mss_hal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif 


### PR DESCRIPTION
Signed-off-by: Francescodario Cuzzocrea <francescodario.cuzzocrea@dorbit.space>

# Description

     * in commit 207d3dfd44b830097606dc20a3a07be82b822889 registers
       definition were moved to mss_rtc.h, but the correspondent include was
       not, causing compilation errors

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Build and boot my firmware

**Test Configuration**:
* Reference design release:
* Hardware:
* HSS version:
* Bare metal examples version:
* Buildroot / Yocto release:

# Checklist:

- [x] I have reviewed my code
- [x] My changes generate no new warnings
