### PR TITLE
Added memory clobber to SP ASM

### DIFF
--- a/mpfs_hal/startup_gcc/system_startup.c
+++ b/mpfs_hal/startup_gcc/system_startup.c
@@ -370,31 +370,31 @@ __attribute__((weak)) int main_other_hart(HLS_DATA* hls)
     {
 
     case 0U:
-        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h0));
+        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h0) : "memory");
         e51();
         break;
 
     case 1U:
         (void)init_pmp((uint8_t)1);
-        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h1));
+        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h1) : "memory");
         u54_1();
         break;
 
     case 2U:
         (void)init_pmp((uint8_t)2);
-        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h2));
+        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h2) : "memory");
         u54_2();
         break;
 
     case 3U:
         (void)init_pmp((uint8_t)3);
-        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h3));
+        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h3) : "memory");
         u54_3();
         break;
 
     case 4U:
         (void)init_pmp((uint8_t)4);
-        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h4));
+        __asm volatile ("add sp, x0, %1" : "=r"(dummy) : "r"(app_stack_top_h4) : "memory");
         u54_4();
         break;
 


### PR DESCRIPTION
# Description

Added memory clobber to inline asm where SP is changed. 
The missing clobber leads on GCC14.2 -02-3 and LTO under specific cases to a wrong optimised code if memory clobber is missing.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Startup code starts up.

**Test Configuration**:
* Reference design release: 2025.07
* Hardware: Disco Board
* HSS version: na
* Bare metal examples version: 2025.07
* Buildroot / Yocto release: na

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
