### PR TITLE
mpfs_hal: preserve DDR pattern-test parameters

### DIFF
--- a/mpfs_hal/common/nwc/mss_ddr.c
+++ b/mpfs_hal/common/nwc/mss_ddr.c
@@ -570,7 +570,7 @@ static uint32_t ddr_setup(void)
     uint32_t ret_status = 0U;
     uint8_t number_of_lanes_to_calibrate;
     uint64_t mem_size;
-    volatile PATTERN_TEST_PARAMS pattern_test;
+    static volatile PATTERN_TEST_PARAMS pattern_test;
 
     ddr_type = LIBERO_SETTING_DDRPHY_MODE & DDRPHY_MODE_MASK;
 


### PR DESCRIPTION
# Description

ddr_setup() retains its DDR training state across invocations, but keeps the associated pattern-test parameters in an automatic variable. The setup state initializes one instance and returns, while later states use new, uninitialized instances.

Give the parameters static storage duration so that they remain valid throughout the DDR training state machine.

Fixes: #36

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**: QEMU
* Reference design release:
* Hardware: Icicle Kit
* HSS version: v2024.06 plus this patch
* Bare metal examples version:
* Buildroot / Yocto release: Buildroot v2026.05

# Checklist:

- [X] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support